### PR TITLE
Fix userForauthentication to reflect kapa reality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18737,7 +18737,7 @@
     },
     "packages/user-management": {
       "name": "@digabi/user-management",
-      "version": "0.6.0-fixUserForAuthentication.0",
+      "version": "0.6.0-fixUserForAuthentication.1",
       "license": "EUPL-1.2",
       "dependencies": {
         "@digabi/validation": "^3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18737,7 +18737,7 @@
     },
     "packages/user-management": {
       "name": "@digabi/user-management",
-      "version": "0.5.0-fixUserForAuthentication.0",
+      "version": "0.6.0-fixUserForAuthentication.0",
       "license": "EUPL-1.2",
       "dependencies": {
         "@digabi/validation": "^3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18417,7 +18417,7 @@
     },
     "packages/2fa": {
       "name": "@digabi/2fa",
-      "version": "2.1.0",
+      "version": "3.0.0",
       "license": "EUPL-1.2",
       "dependencies": {
         "qr": "^0.5.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -18737,7 +18737,7 @@
     },
     "packages/user-management": {
       "name": "@digabi/user-management",
-      "version": "0.4.0",
+      "version": "0.5.0-fixUserForAuthentication.0",
       "license": "EUPL-1.2",
       "dependencies": {
         "@digabi/validation": "^3.1.0",

--- a/packages/2fa/package.json
+++ b/packages/2fa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digabi/2fa",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "author": "Matriculation Examination Board, Finland",
   "license": "EUPL-1.2",
   "repository": {

--- a/packages/user-management/package.json
+++ b/packages/user-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digabi/user-management",
-  "version": "0.6.0-fixUserForAuthentication.0",
+  "version": "0.6.0-fixUserForAuthentication.1",
   "author": "Matriculation Examination Board, Finland",
   "license": "EUPL-1.2",
   "repository": {

--- a/packages/user-management/package.json
+++ b/packages/user-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digabi/user-management",
-  "version": "0.4.0",
+  "version": "0.5.0-fixUserForAuthentication.0",
   "author": "Matriculation Examination Board, Finland",
   "license": "EUPL-1.2",
   "repository": {

--- a/packages/user-management/package.json
+++ b/packages/user-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digabi/user-management",
-  "version": "0.5.0-fixUserForAuthentication.0",
+  "version": "0.6.0-fixUserForAuthentication.0",
   "author": "Matriculation Examination Board, Finland",
   "license": "EUPL-1.2",
   "repository": {

--- a/packages/user-management/src/user-types.ts
+++ b/packages/user-management/src/user-types.ts
@@ -141,7 +141,8 @@ export const UserSchema = StoredUserDetailsSchema.extend({
   ssn: zodSsn,
   userAccountId: z.string(),
   schools: z.array(UserSchoolSchema),
-  censorRole: CensorRoleSchema.optional()
+  censorRole: CensorRoleSchema.optional(),
+  impersonation: z.never().optional()
 })
 
 export type UserToUpsert = z.infer<typeof UserToUpsertSchema>
@@ -151,7 +152,8 @@ export const UserToUpsertSchema = UserDetailsSchema.extend({
 }).strict()
 
 export type ImpersonatedUser = z.infer<typeof ImpersonatedUserSchema>
-const ImpersonatedUserSchema = z.object({
+const ImpersonatedUserSchema = StoredUserDetailsSchema.extend({
+  userAccountId: z.string().optional(),
   ssn: z.string(),
   schools: z.array(UserSchoolSchema),
   impersonation: ImpersonationSchema,

--- a/packages/user-management/src/user-types.ts
+++ b/packages/user-management/src/user-types.ts
@@ -143,7 +143,7 @@ export const UserSchema = StoredUserDetailsSchema.extend({
   schools: z.array(UserSchoolSchema),
   censorRole: CensorRoleSchema.optional(),
   impersonation: z.never().optional()
-})
+}).strict()
 
 export type UserToUpsert = z.infer<typeof UserToUpsertSchema>
 export const UserToUpsertSchema = UserDetailsSchema.extend({
@@ -151,17 +151,32 @@ export const UserToUpsertSchema = UserDetailsSchema.extend({
   schools: z.array(UserSchoolToUpsertSchema)
 }).strict()
 
-export type ImpersonatedUser = z.infer<typeof ImpersonatedUserSchema>
-const ImpersonatedUserSchema = StoredUserDetailsSchema.extend({
-  userAccountId: z.string().optional(),
-  ssn: z.string(),
-  schools: z.array(UserSchoolSchema),
-  impersonation: ImpersonationSchema,
-  censorRole: CensorRoleSchema.optional()
-})
+export type PersonalImpersonation = z.infer<typeof personalImpersonationSchema>
+export const personalImpersonationSchema = UserSchema.extend({
+  impersonation: ImpersonationSchema
+}).strict()
 
+export type SchoolImpersonation = z.infer<typeof schoolImpersonationSchema>
+export const schoolImpersonationSchema = z
+  .object({
+    impersonation: ImpersonationSchema,
+    ssn: z.literal('IMPERSONATED'),
+    schools: z
+      .array(
+        z.object({
+          schoolId: z.string(),
+          principal: z.literal(true),
+          permissions: z.array(z.unknown()).max(0, "Impersonated principal doesn't have other permissions")
+        })
+      )
+      .max(1, 'Impersonated principal has one school')
+  })
+  .strict()
+
+export type ImpersonatedUser = z.infer<typeof ImpersonatedUserSchema>
+export const ImpersonatedUserSchema = z.xor([personalImpersonationSchema, schoolImpersonationSchema])
 export type UserForAuthentication = z.infer<typeof UserForAuthenticationSchema>
-export const UserForAuthenticationSchema = z.union([UserSchema, ImpersonatedUserSchema])
+export const UserForAuthenticationSchema = z.xor([UserSchema, ImpersonatedUserSchema])
 
 export type UserWithSchoolRoleAndSchoolId = z.infer<typeof UserWithSchoolRoleAndSchoolIdSchema>
 export const UserWithSchoolRoleAndSchoolIdSchema = z.object({

--- a/packages/user-management/src/user-types.ts
+++ b/packages/user-management/src/user-types.ts
@@ -18,13 +18,13 @@ export const PrincipalOrganizationSchema = z.object({
 
 export type Impersonation = z.infer<typeof ImpersonationSchema>
 export const ImpersonationSchema = z.object({
-  id: z.number(),
+  id: z.uuid(),
   realSsn: zodSsn,
-  impersonatedSsn: zodSsn,
+  impersonatedSsn: zodSsn.or(z.literal('')),
   explanation: z.string(),
   validityStart: z.string(),
   validityEnd: z.string(),
-  schoolUuid: z.string().optional()
+  schoolUuid: z.string().nullish()
 })
 
 export type MockUser = z.infer<typeof MockUserSchema>

--- a/packages/user-management/src/user-types.ts
+++ b/packages/user-management/src/user-types.ts
@@ -151,13 +151,13 @@ export const UserToUpsertSchema = UserDetailsSchema.extend({
   schools: z.array(UserSchoolToUpsertSchema)
 }).strict()
 
-export type PersonalImpersonation = z.infer<typeof personalImpersonationSchema>
-export const personalImpersonationSchema = UserSchema.extend({
+export type PersonalImpersonation = z.infer<typeof PersonalImpersonationSchema>
+export const PersonalImpersonationSchema = UserSchema.extend({
   impersonation: ImpersonationSchema
 }).strict()
 
-export type SchoolImpersonation = z.infer<typeof schoolImpersonationSchema>
-export const schoolImpersonationSchema = z
+export type SchoolImpersonation = z.infer<typeof SchoolImpersonationSchema>
+export const SchoolImpersonationSchema = z
   .object({
     impersonation: ImpersonationSchema,
     ssn: z.literal('IMPERSONATED'),
@@ -174,7 +174,7 @@ export const schoolImpersonationSchema = z
   .strict()
 
 export type ImpersonatedUser = z.infer<typeof ImpersonatedUserSchema>
-export const ImpersonatedUserSchema = z.xor([personalImpersonationSchema, schoolImpersonationSchema])
+export const ImpersonatedUserSchema = z.xor([PersonalImpersonationSchema, SchoolImpersonationSchema])
 export type UserForAuthentication = z.infer<typeof UserForAuthenticationSchema>
 export const UserForAuthenticationSchema = z.xor([UserSchema, ImpersonatedUserSchema])
 


### PR DESCRIPTION
When impersonating an ssn that has an user account the userAccountId will exist and the userdetails might also exist though in production some accounts don't have them